### PR TITLE
Bulk discount delete

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -14,6 +14,12 @@ class BulkDiscountsController < ApplicationController
     redirect_to "/merchant/#{@merchant.id}/bulk_discounts"
   end
 
+  def destroy
+    bulk_discount = BulkDiscount.find(params[:id])
+    bulk_discount.destroy
+    redirect_to "/merchant/#{params[:merchant_id]}/bulk_discounts"
+  end
+
 private
   def bulk_discount_params
     params.permit(:discount, :threshold)

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -1,10 +1,16 @@
 <h1>Bulk Discounts Index Page</h1>
 
 <h3>My Bulk Discounts</h3>
-<% @bd.each do |discount| %>
-  <p>Threshold: <%= discount.threshold  %>,
-    Discount: <%= discount.discount %>%  -
-  <%= link_to "View Bulk Discount ##{discount.id}", merchant_bulk_discount_path(discount.merchant.id, discount.id) %></p>
+<% if @merchant.bulk_discounts.empty? %>
+  <p><%= @merchant.name %> does not currently have any bulk discounts!</p>
+<% else %>
+  <% @bd.each do |discount| %>
+    <div id=discount-<%= discount.id %>>
+      <p>Threshold: <%= discount.threshold  %>,
+        Discount: <%= discount.discount %>%  -
+      <%= link_to "View Bulk Discount ##{discount.id}", merchant_bulk_discount_path(discount.merchant.id, discount.id) %>
+      <%= link_to "Delete Bulk Discount ##{discount.id}", merchant_bulk_discount_path(discount.merchant.id, discount.id), method: :delete %></p>
+    </div>
+  <% end %>
 <% end %>
-
 <%= link_to "Create a New Bulk Discount", new_merchant_bulk_discount_path(@merchant.id) %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,7 +5,7 @@ Rails.application.routes.draw do
     resources :items, except: [:destroy]
     resources :item_status, only: [:update]
     resources :invoices, only: [:index, :show, :update]
-    resources :bulk_discounts, only: [:index, :new, :create, :show]
+    resources :bulk_discounts, only: [:index, :new, :create, :show, :destroy]
   end
 
   namespace :admin do

--- a/spec/features/bulk_discounts/index_spec.rb
+++ b/spec/features/bulk_discounts/index_spec.rb
@@ -82,14 +82,61 @@ RSpec.describe 'merchants bulk discount index page' do
     expect(page).to have_content("Discount: 10")
   end
 
-  # Merchant Bulk Discount Create
-  #
-  # As a merchant
-  # When I visit my bulk discounts index
-  # Then I see a link to create a new discount
-  # When I click this link
-  # Then I am taken to a new page where I see a form to add a new bulk discount
-  # When I fill in the form with valid data
-  # Then I am redirected back to the bulk discount index
-  # And I see my new bulk discount listed
+  it 'has a link next to each discount to delete that discount' do
+    within "#discount-#{@bd1.id}" do
+      expect(page).to have_link("Delete Bulk Discount ##{@bd1.id}")
+    end
+
+    within "#discount-#{@bd2.id}" do
+      expect(page).to have_link("Delete Bulk Discount ##{@bd2.id}")
+    end
+
+    within "#discount-#{@bd3.id}" do
+      expect(page).to have_link("Delete Bulk Discount ##{@bd3.id}")
+    end
+  end
+
+  it 'has a link that removes that discount from the page' do
+    click_link "Delete Bulk Discount ##{@bd1.id}"
+    expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts")
+    expect(page).to_not have_content(@bd1.id)
+    expect(page).to have_content(@bd2.id)
+    expect(page).to have_content(@bd3.id)
+
+    click_link "Delete Bulk Discount ##{@bd2.id}"
+    expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts")
+    expect(page).to_not have_content(@bd1.id)
+    expect(page).to_not have_content(@bd2.id)
+    expect(page).to have_content(@bd3.id)
+
+    click_link "Delete Bulk Discount ##{@bd3.id}"
+    expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts")
+    expect(page).to_not have_content(@bd1.id)
+    expect(page).to_not have_content(@bd2.id)
+    expect(page).to_not have_content(@bd3.id)
+  end
+
+  # EDGE CASE
+  it 'shows that no bulk discounts exist when the merchant doesnt have any' do
+    click_link "Delete Bulk Discount ##{@bd1.id}"
+    expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts")
+    expect(page).to_not have_content(@bd1.id)
+    expect(page).to have_content(@bd2.id)
+    expect(page).to have_content(@bd3.id)
+
+    click_link "Delete Bulk Discount ##{@bd2.id}"
+    expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts")
+    expect(page).to_not have_content(@bd1.id)
+    expect(page).to_not have_content(@bd2.id)
+    expect(page).to have_content(@bd3.id)
+
+    click_link "Delete Bulk Discount ##{@bd3.id}"
+    expect(current_path).to eq("/merchant/#{@merchant1.id}/bulk_discounts")
+    expect(page).to_not have_content(@bd1.id)
+    expect(page).to_not have_content(@bd2.id)
+    expect(page).to_not have_content(@bd3.id)
+
+    # EDGE CASE EXPECT
+    expect(page).to have_content("#{@merchant1.name} does not currently have any bulk discounts!")
+  end
 end


### PR DESCRIPTION
User Story 5 including a delete for each bulk discount.

Added sad path/edge case to give feedback to the user when looking at a merchant's bulk discount index when there are none to show.